### PR TITLE
Allow use of Plain Ruby Subclasses

### DIFF
--- a/lib/attribute_normalizer/model_inclusions.rb
+++ b/lib/attribute_normalizer/model_inclusions.rb
@@ -62,7 +62,9 @@ module AttributeNormalizer
 
     def inherited(subclass)
       super
-      subclass.normalize_default_attributes if subclass.table_exists?
+      if subclass.respond_to?(:table_exists?) && subclass.table_exists?
+        subclass.normalize_default_attributes
+      end
     end
   end
 end


### PR DESCRIPTION
Following on the heels of [allowing compatibility with Plain Old Ruby objects](https://github.com/mdeering/attribute_normalizer/commit/bb389b3a64faebbb8277424647ec0f8605dfab0b), this commit avoids calling `table_exists?` for objects that don't respond to that method.
