### PR TITLE
Respect custom attribute methods in activerecord models

### DIFF
--- a/lib/attribute_normalizer/model_inclusions.rb
+++ b/lib/attribute_normalizer/model_inclusions.rb
@@ -39,16 +39,17 @@ module AttributeNormalizer
 
         if method_defined?(:"#{attribute}=")
           alias_method "old_#{attribute}=", "#{attribute}="
-        end
 
-        define_method "#{attribute}=" do |value|
-          begin
-            super(self.send(:"normalize_#{attribute}", value))
-          rescue NoMethodError
+          define_method "#{attribute}=" do |value|
             normalized_value = self.send(:"normalize_#{attribute}", value)
             self.send("old_#{attribute}=", normalized_value)
           end
+        else
+          define_method "#{attribute}=" do |value|
+            super(self.send(:"normalize_#{attribute}", value))
+          end
         end
+
 
       end
     end


### PR DESCRIPTION
normalize_attributes ignores custom setter methods for db columns defined in ActiveRecord models, by passing value directly to superclass. Fixed this.
