### PR TITLE
Fixing missing table_exists?

### DIFF
--- a/lib/attribute_normalizer/model_inclusions.rb
+++ b/lib/attribute_normalizer/model_inclusions.rb
@@ -72,7 +72,7 @@ module AttributeNormalizer
 
     def inherited(subclass)
       super
-      if subclass.respond_to?(:table_exists?) && (subclass.table_exists? rescue false)
+      if subclass.name.present? && subclass.respond_to?(:table_exists?) && (subclass.table_exists? rescue false)
         subclass.normalize_default_attributes
       end
     end


### PR DESCRIPTION
In some contexts (for example when using RubyCas, which dynamically defines an ActiveRecord model upon self.included?) a call to subclass.respond_to?(:table_exists?) will fail as the still initializing subclass will not have a name to resolve to, which leads to a SQL call like 

SELECT '' FROM ''.

Checking the presence of the name will prevent this type of error, by skipping the attribute normalizer entirely.
