### PR TITLE
Secure rubygems url and sqlite gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,5 @@ group :development do
   gem 'mongoid'
   gem 'rake'
   gem 'rspec'
-  gem 'sqlite3-ruby'
+  gem 'sqlite3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,8 +47,6 @@ GEM
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.8.0)
     sqlite3 (1.3.5)
-    sqlite3-ruby (1.3.3)
-      sqlite3 (>= 1.3.3)
     thor (0.14.6)
     tzinfo (0.3.31)
 
@@ -64,4 +62,4 @@ DEPENDENCIES
   mongoid
   rake
   rspec
-  sqlite3-ruby
+  sqlite3


### PR DESCRIPTION
- Fixed deprecation warning about using `source :rubygems` in Gemfile
- The sqlite3-ruby gem has changed it's name to just sqlite3
