### PR TITLE
Use squeeze instead of gsub in SquishNormalizer

### DIFF
--- a/lib/attribute_normalizer/normalizers/squish_normalizer.rb
+++ b/lib/attribute_normalizer/normalizers/squish_normalizer.rb
@@ -2,7 +2,7 @@ module AttributeNormalizer
   module Normalizers
     module SquishNormalizer
       def self.normalize(value, options = {})
-        value.is_a?(String) ? value.strip.squeeze : value
+        value.is_a?(String) ? value.strip.squeeze(' ') : value
       end
     end
   end

--- a/spec/author_spec.rb
+++ b/spec/author_spec.rb
@@ -13,7 +13,7 @@ describe Author do
     it { should normalize_attribute(:first_name).from('    ').to('') }
 
     # :squish normalizer
-    it { should normalize_attribute(:nickname).from(' this    nickname  ').to('this nickname') }
+    it { should normalize_attribute(:nickname).from(' hello    world  ').to('hello world') }
 
     # :blank normalizer
     it { should normalize_attribute(:last_name).from('').to(nil) }


### PR DESCRIPTION
According to [these benchmarks](https://gist.github.com/samleb/9455926), using `squeeze` is an order of magnitude faster than `gsub` when dealing with squishing/squeezing spaces on almost all Ruby implementations, except on Rubinius where it doesn't make much of a difference.
Here is a patch that replaces `gsub` by `squeeze` in `SquishNormalizer.normalize`, with all tests green :)
