### PR TITLE
Introduce :control_chars to remove all control characters but spaces

### DIFF
--- a/lib/attribute_normalizer.rb
+++ b/lib/attribute_normalizer.rb
@@ -4,6 +4,7 @@ require 'attribute_normalizer/normalizers/strip_normalizer'
 require 'attribute_normalizer/normalizers/squish_normalizer'
 require 'attribute_normalizer/normalizers/whitespace_normalizer'
 require 'attribute_normalizer/normalizers/boolean_normalizer'
+require 'attribute_normalizer/normalizers/control_chars_normalizer'
 
 module AttributeNormalizer
 
@@ -32,12 +33,13 @@ module AttributeNormalizer
     def initialize
 
       @normalizers = {
-        :blank      => AttributeNormalizer::Normalizers::BlankNormalizer,
-        :phone      => AttributeNormalizer::Normalizers::PhoneNormalizer,
-        :squish     => AttributeNormalizer::Normalizers::SquishNormalizer,
-        :strip      => AttributeNormalizer::Normalizers::StripNormalizer,
-        :whitespace => AttributeNormalizer::Normalizers::WhitespaceNormalizer,
-        :boolean    => AttributeNormalizer::Normalizers::BooleanNormalizer
+        :blank         => AttributeNormalizer::Normalizers::BlankNormalizer,
+        :phone         => AttributeNormalizer::Normalizers::PhoneNormalizer,
+        :squish        => AttributeNormalizer::Normalizers::SquishNormalizer,
+        :strip         => AttributeNormalizer::Normalizers::StripNormalizer,
+        :whitespace    => AttributeNormalizer::Normalizers::WhitespaceNormalizer,
+        :boolean       => AttributeNormalizer::Normalizers::BooleanNormalizer,
+        :control_chars => AttributeNormalizer::Normalizers::ControlCharsNormalizer
       }
 
       @default_normalizers = [ :strip, :blank ]

--- a/lib/attribute_normalizer/normalizers/control_chars_normalizer.rb
+++ b/lib/attribute_normalizer/normalizers/control_chars_normalizer.rb
@@ -1,0 +1,9 @@
+module AttributeNormalizer
+  module Normalizers
+    module ControlCharsNormalizer
+      def self.normalize(value, options = {})
+        value.is_a?(String) ? value.gsub(/[[:cntrl:]&&[^[:space:]]]/, '') : value
+      end
+    end
+  end
+end

--- a/spec/author_spec.rb
+++ b/spec/author_spec.rb
@@ -25,6 +25,10 @@ describe Author do
     it { should normalize_attribute(:biography).from("\tthis\tline\nbreak ").to("this line\nbreak") }
     it { should normalize_attribute(:biography).from("  \tthis  \tline  \nbreak \t  \nthis").to("this line\nbreak\nthis") }
     it { should normalize_attribute(:biography).from('    ').to('') }
+    
+    # :control_chars normalizer
+    it { should normalize_attribute(:bibliography).from("No \bcontrol\u0003 chars").to("No control chars") }
+    it { should normalize_attribute(:bibliography).from("Except for\tspaces.\r\nAll kinds").to("Except for\tspaces.\r\nAll kinds") }
   end
 
   context 'on default attribute with the default normalizer changed' do

--- a/spec/connection_and_schema.rb
+++ b/spec/connection_and_schema.rb
@@ -17,6 +17,7 @@ ActiveRecord::Schema.define do
     t.string :last_name
     t.string :phone_number
     t.text   :biography
+    t.text   :bibliography
   end
 
   create_table :books, :force => true do |t|

--- a/spec/models/author.rb
+++ b/spec/models/author.rb
@@ -6,5 +6,6 @@ class Author < ActiveRecord::Base
   normalize_attribute :last_name,    :with => :blank
   normalize_attribute :phone_number, :with => :phone
   normalize_attribute :biography,    :with => :whitespace
+  normalize_attribute :bibliography, :with => :control_chars
 
 end


### PR DESCRIPTION
Here is a normalizer that I've been using a lot in day-to-day applications.
I thought it might come useful to other people too...
Specs are included, I'll take time to write some documentation if actually needed.
