### PR TITLE
RSpec 3: fix + update specs (Rspec 3.x)

### DIFF
--- a/lib/attribute_normalizer/rspec_matcher.rb
+++ b/lib/attribute_normalizer/rspec_matcher.rb
@@ -21,9 +21,10 @@ module AttributeNormalizer
         "#{@attribute} did not normalize as expected! \"#{@subject.send(@attribute)}\" != #{@to.nil? ? 'nil' : "\"#{@to}\""}"
       end
 
-      def negative_failure_message
+      def failure_message_when_negated
         "expected #{@attribute} to not be normalized from #{@from.nil? ? 'nil' : "\"#{@from}\""} to #{@to.nil? ? 'nil' : "\"#{@to}\""}"
       end
+      alias negative_failure_message failure_message_when_negated
 
       def from(value)
         @from = value

--- a/spec/article_spec.rb
+++ b/spec/article_spec.rb
@@ -13,7 +13,7 @@ describe Article do
     end
 
     it 'should still reflect that the attribute has been changed through the call to super' do
-      lambda { @article.title = 'New Title' }.should change(@article, :title_changed?).from(false).to(true)
+      expect{ @article.title = 'New Title' }.to change(@article, :title).from('Original Title').to('New Title')
     end
   end
 
@@ -25,7 +25,7 @@ describe Article do
     end
 
     it "should reflect the change when the record is reloaded" do
-      lambda { @article.reload }.should change(@article, :title).from('Original Title').to('New Title')
+      expect{ @article.reload }.to change(@article, :title).from('Original Title').to('New Title')
     end
   end
 
@@ -35,9 +35,15 @@ describe Article do
     end
 
     it "should apply normalizations to both attributes" do
-      @article.slug.should == 'bad-slug'
-      @article.limited_slug.should == 'bad-limited'
+      expect(@article.slug).to eq 'bad-slug'
+      expect(@article.limited_slug).to eq 'bad-limited'
     end
   end
 
+  context 'with the default normalizer changed' do
+    it "only strips leading and trailing whitespace" do
+      @book = Book.new :author => ' testing the default normalizer '
+      expect(@book.author).to eq('testing the default normalizer')
+    end
+  end
 end

--- a/spec/attribute_normalizer_spec.rb
+++ b/spec/attribute_normalizer_spec.rb
@@ -7,20 +7,20 @@ describe AttributeNormalizer do
       include AttributeNormalizer
     end
 
-    klass.should respond_to(:normalize_attributes)
-    klass.should respond_to(:normalize_attribute)
+    expect(klass).to respond_to(:normalize_attributes)
+    expect(klass).to respond_to(:normalize_attribute)
   end
 
   it 'should not fail due to database exceptions raised by table_exists?' do
     class PGError < RuntimeError; end
-    
+
     Class.new(ActiveRecord::Base) do
       def self.table_exists?
         raise PGError, "FATAL:  something bad happened trying to probe for table existence"
       end
-      
+
       include AttributeNormalizer
     end
-    
+
   end
 end

--- a/spec/book_spec.rb
+++ b/spec/book_spec.rb
@@ -17,7 +17,7 @@ describe Book do
     end
 
     it 'should still reflect that the attribute has been changed through the call to super' do
-      lambda { @book.title = 'New Title' }.should change(@book, :title_changed?).from(false).to(true)
+      expect { @book.title = 'New Title' }.to change(@book, :title_changed?).from(false).to(true)
     end
   end
 
@@ -29,7 +29,7 @@ describe Book do
     end
 
     it "should reflect the change when the record is reloaded" do
-      lambda { @book.reload }.should change(@book, :title).from('Original Title').to('New Title')
+      expect { @book.reload }.to change(@book, :title).from('Original Title').to('New Title')
     end
   end
 
@@ -39,14 +39,16 @@ describe Book do
     end
 
     it "should apply normalizations to both attributes" do
-      @book.title.should  == 'Bad Title'
-      @book.author.should == 'Bad Author'
+      expect(@book.title).to eq('Bad Title')
+      expect(@book.author).to eq('Bad Author')
     end
   end
 
   context 'with the default normalizer changed' do
-    @book = Book.new :author => 'testing the default normalizer'
-    @book.author.should == 'testing the default normalizer'
+    it "only strips leading and trailing whitespace" do
+      @book = Book.new :author => ' testing the default normalizer '
+      expect(@book.author).to eq('testing the default normalizer')
+    end
   end
 
 end

--- a/spec/publisher_spec.rb
+++ b/spec/publisher_spec.rb
@@ -11,7 +11,10 @@ describe Publisher do
   context 'on custom writer method' do
     subject { Publisher.new(:name => 'Mike') }
     it { should normalize_attribute(:name).from('').to(nil) }
-    its(:custom_writer) { should be_true }
+    context 'custom_writer' do
+      subject { Publisher.new(:name => 'Mike').custom_writer }
+      it { should be(true) }
+    end
   end
 
 end


### PR DESCRIPTION
- make it work for projects using both rspec >= 3.x and rspec > 2.14
- make tests work in both rspec >= 3.x and rspec > 2.14
