### PR TITLE
Fixing font size in README.md

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -53,6 +53,7 @@ h3. Rails 2
 config.gem 'attribute_normalizer'</code></pre>
 
 h3. Rails 3
+
 <pre><code># Gemfile
 gem 'attribute_normalizer'</code></pre>
 


### PR DESCRIPTION
Added a line break to fix the font size of the Rails 3 example in the README.md.