### PR TITLE
Evaluate normalization block in the context of the object

### DIFF
--- a/lib/attribute_normalizer/model_inclusions.rb
+++ b/lib/attribute_normalizer/model_inclusions.rb
@@ -30,7 +30,7 @@ module AttributeNormalizer
             normalized = normalizer.respond_to?(:normalize) ? normalizer.normalize( normalized , options) : normalizer.call(normalized, options)
           end
 
-          normalized = block_given? ? yield(normalized) : normalized
+          normalized = block_given? ? instance_exec(normalized, &block) : normalized
 
           if block_given?
             post_normalizers.each do |normalizer_name|

--- a/spec/connection_and_schema.rb
+++ b/spec/connection_and_schema.rb
@@ -7,7 +7,9 @@ ActiveRecord::Base.establish_connection({
 ActiveRecord::Schema.define do
   create_table :publishers, :force => true do |t|
     t.string :name
+    t.string :country
     t.string :phone_number
+    t.string :international_phone_number
   end
 
   create_table :authors, :force => true do |t|

--- a/spec/models/publisher.rb
+++ b/spec/models/publisher.rb
@@ -10,4 +10,8 @@ class Publisher < ActiveRecord::Base
   normalize_attribute :name,         :with => :blank
   normalize_attribute :phone_number, :with => :phone
 
+  normalize_attribute :international_phone_number do |number|
+    self.country == 'fr' ? number.sub(/^0/,'+33') : number
+  end
+
 end

--- a/spec/publisher_spec.rb
+++ b/spec/publisher_spec.rb
@@ -8,6 +8,11 @@ describe Publisher do
     it { should normalize_attribute(:phone_number).from('+ 1 (877) 987-9875').to('18779879875') }
   end
 
+  context 'access to object in normalizer block' do
+    subject { Publisher.new(:country => 'fr') }
+    it { should normalize_attribute(:international_phone_number).from('0612345678').to('+33612345678') }
+  end
+
   context 'on custom writer method' do
     subject { Publisher.new(:name => 'Mike') }
     it { should normalize_attribute(:name).from('').to(nil) }


### PR DESCRIPTION
Hello,

I came across the very problem specified in the specs included in this PR, that is needing to have access to another field to decide how to normalize my attribute.

I know I could just override a custom writer for that, but I felt this modification, while unobtrusive, makes the block given to normalize_attribute behave as one would expect.

Cheers
