### PR TITLE
Use attribute_missing instead of super

### DIFF
--- a/lib/attribute_normalizer/model_inclusions.rb
+++ b/lib/attribute_normalizer/model_inclusions.rb
@@ -57,7 +57,9 @@ module AttributeNormalizer
           end
         else
           define_method "#{attribute}=" do |value|
-            super(self.send(:"normalize_#{attribute}", value))
+            normalized_value = self.send(:"normalize_#{attribute}", value)
+            match = matched_attribute_method("#{attribute}=")
+            match ? attribute_missing(match, normalized_value) : super
           end
         end
 


### PR DESCRIPTION
Using Rails 5, +super+ does not work and results in:

  NoMethodError: super: no superclass method `<attribute>=` ...

This change just copies
https://github.com/rails/rails/blob/v5.1.4/activemodel/lib/active_model/attribute_methods.rb#L431-L432
from +method_missing+.

I guess this is not the change you want to make in this gem, but it was the easiest fix for the app I'm working on and I thought I'll open the PR here anyway as an example. Also - where we use attribute_normalizer we do a lot of weird things so this error might be caused by some of that stuff as well.